### PR TITLE
docs: fix macOS install docs and add Apple Silicon GPU troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,19 @@ No SDK. No driver toolkit. No package manager. Download one binary, run it.
 irm https://octoflow-lang.github.io/octoflow/install.ps1 | iex
 ```
 
-**Linux / macOS** (bash):
+**Linux** (bash):
 ```bash
 curl -fsSL https://octoflow-lang.github.io/octoflow/install.sh | sh
+```
+
+**macOS (Apple Silicon)**:
+```bash
+# Download the latest `octoflow-*-aarch64-macos.tar.gz` from Releases,
+# then run:
+tar xzf octoflow-*-aarch64-macos.tar.gz
+chmod +x octoflow
+mv octoflow /usr/local/bin/
+octoflow --version
 ```
 
 Or download directly from [Releases](https://github.com/octoflow-lang/octoflow/releases/latest).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,6 +32,12 @@ sudo mv octoflow /usr/local/bin/
 octoflow --version
 ```
 
+Or use the Linux installer script:
+
+```bash
+curl -fsSL https://octoflow-lang.github.io/octoflow/install.sh | sh
+```
+
 ## macOS (Apple Silicon)
 
 ```bash
@@ -40,6 +46,8 @@ chmod +x octoflow
 mv octoflow /usr/local/bin/
 octoflow --version
 ```
+
+Use direct release download on macOS. The `install.sh` script is Linux-only.
 
 GPU compute uses MoltenVK (Vulkan on Metal). No additional setup needed
 on M1/M2/M3/M4 Macs.
@@ -65,6 +73,20 @@ If no GPU line appears, check:
 - **Vulkan drivers** are installed (NVIDIA: included with driver, AMD: included with Adrenalin, Intel: included with driver)
 - **Integrated GPUs** work if they support Vulkan 1.0+
 - OctoFlow falls back to CPU for all GPU operations — everything still runs
+
+### macOS troubleshooting (MoltenVK portability)
+
+If you see `No GPU detected` and Vulkan loader errors mentioning
+`VK_KHR_portability_enumeration`, this is a runtime initialization issue.
+The Vulkan instance must enable portability enumeration on macOS.
+
+Please open an issue with:
+
+```bash
+VK_LOADER_DEBUG=all octoflow run examples/hello_gpu.flow
+```
+
+Include the output so maintainers can confirm the portability-enumeration path.
 
 ## Updating
 


### PR DESCRIPTION
## Summary
- split README install instructions so `install.sh` is clearly Linux-only and add explicit macOS Apple Silicon extraction steps from Releases
- update `docs/installation.md` with Linux installer-script note and a macOS note to use direct release downloads
- add a macOS troubleshooting section for Vulkan portability-enumeration failures (`VK_KHR_portability_enumeration`) with a reproducible debug command for issue reports

## Why
The current README suggests `install.sh` works on macOS, but the script exits with a Linux-only error. Also, Apple Silicon users can hit Vulkan portability-enumeration runtime failures that present as `No GPU detected`; documenting this helps users and gives maintainers actionable bug reports.